### PR TITLE
Add ADVANCED_GIT_BRANCH back into dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ RUN \
 	pycryptodomex && \
 
 # install app
- git clone --depth 1 https://github.com/JonnyWong16/plexpy /app/plexpy && \
+ [ "$ADVANCED_GIT_BRANCH" ] && \
+	echo "Using this variable is unsupported., THERE IS NO PATH BACK TO MASTER GIT BRANCH OTHER THAN REMOVING EXISTING APPDATA FOLDER, WE MEAN IT WHEN WE SAY UNSUPPORTED" || \
+	ADVANCED_GIT_BRANCH="master" && \
+ git clone --branch $ADVANCED_GIT_BRANCH --depth 1 https://github.com/JonnyWong16/plexpy /app/plexpy && \
 
 # cleanup
  apk del --purge \


### PR DESCRIPTION
ADVANCED_GIT_BRANCH was removed when changing the git clone process, I am aware this feature is not supported but as one of the devs working on and with plexpy i use this feature extensively, so i've added the branch code to the new location of git clone

Thanks