### PR TITLE
Updated dockerfile to use optional git branch as an argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM lsiobase/alpine.python:3.7
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+ARG BRANCH="master"
+LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE} Branch: - ${BRANCH}"
 LABEL maintainer="sparklyballs"
 
 RUN \
@@ -17,7 +18,7 @@ RUN \
  pip install --no-cache-dir -U \
 	pycryptodomex && \
  echo "**** install app ****" && \
- git clone --depth 1 https://github.com/JonnyWong16/plexpy /app/plexpy && \
+ git clone -b ${BRANCH} --depth 1 https://github.com/JonnyWong16/plexpy /app/plexpy && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \


### PR DESCRIPTION
Hi,

This closes issue #45 by adding an optional build argument to select a Git branch.

    docker build --build-arg BRANCH=beta -t tankbusta/plexpy:beta .